### PR TITLE
Allow ref_to_token_annotations to handle more general cases

### DIFF
--- a/deep_reference_parser/prodigy/reference_to_token_annotations.py
+++ b/deep_reference_parser/prodigy/reference_to_token_annotations.py
@@ -10,7 +10,6 @@ from ..logger import logger
 
 
 class TokenTagger:
-
     def __init__(self, task="splitting", lowercase=True):
         """
         Converts data in prodigy format with full reference spans to per-token
@@ -67,7 +66,7 @@ class TokenTagger:
 
         # Sort by token id to ensure it is ordered.
 
-        spans = sorted(spans, key=lambda k: k['token_start'])
+        spans = sorted(spans, key=lambda k: k["token_start"])
 
         doc["spans"] = spans
 
@@ -86,7 +85,6 @@ class TokenTagger:
             self.out.append(self.tag_doc(doc))
 
         return self.out
-
 
     def reference_spans(self, spans, tokens, task):
         """
@@ -134,7 +132,6 @@ class TokenTagger:
 
         return split_spans
 
-
     def outside_spans(self, spans, tokens):
         """
         Label tokens with `o` if they are outside a reference
@@ -161,7 +158,6 @@ class TokenTagger:
 
         return outside_spans
 
-
     def create_span(self, tokens, index, label):
         """
         Given a list of tokens, (in prodigy format) and an index relating to one of
@@ -181,7 +177,6 @@ class TokenTagger:
 
         return span
 
-
     def split_long_span(self, tokens, span, start_label, end_label, inside_label):
         """
         Split a multi-token span into `n` spans of lengh `1`, where `n=len(tokens)`
@@ -192,40 +187,42 @@ class TokenTagger:
         spans.append(self.create_span(tokens, span["token_end"], end_label))
 
         for index in range(span["token_start"] + 1, span["token_end"]):
-                spans.append(self.create_span(tokens, index, inside_label))
+            spans.append(self.create_span(tokens, index, inside_label))
 
-        spans = sorted(spans, key=lambda k: k['token_start'])
+        spans = sorted(spans, key=lambda k: k["token_start"])
 
         return spans
+
 
 @plac.annotations(
     input_file=(
         "Path to jsonl file containing chunks of references in prodigy format.",
         "positional",
         None,
-        str
+        str,
     ),
     output_file=(
         "Path to jsonl file into which fully annotate files will be saved.",
         "positional",
         None,
-        str
+        str,
     ),
     task=(
         "Which task is being performed. Either splitting or parsing.",
         "positional",
         None,
-        str
+        str,
     ),
     lowercase=(
         "Convert UPPER case reference labels to lower case token labels?",
         "flag",
         "f",
-        bool
-    )
+        bool,
+    ),
 )
-
-def reference_to_token_annotations(input_file, output_file, task="splitting", lowercase=False):
+def reference_to_token_annotations(
+    input_file, output_file, task="splitting", lowercase=False
+):
     """
     Creates a span for every token from existing multi-token spans
 
@@ -262,8 +259,12 @@ def reference_to_token_annotations(input_file, output_file, task="splitting", lo
     not_annotated_docs = [doc for doc in ref_annotated_docs if not doc.get("spans")]
     ref_annotated_docs = [doc for doc in ref_annotated_docs if doc.get("spans")]
 
-    logger.info("Loaded %s documents with reference annotations", len(ref_annotated_docs))
-    logger.info("Loaded %s documents with no reference annotations", len(not_annotated_docs))
+    logger.info(
+        "Loaded %s documents with reference annotations", len(ref_annotated_docs)
+    )
+    logger.info(
+        "Loaded %s documents with no reference annotations", len(not_annotated_docs)
+    )
 
     annotator = TokenTagger(task=task, lowercase=lowercase)
 
@@ -272,7 +273,11 @@ def reference_to_token_annotations(input_file, output_file, task="splitting", lo
 
     write_jsonl(all_docs, output_file=output_file)
 
-    logger.info("Wrote %s docs with token annotations to %s",
-                len(token_annotated_docs), output_file)
-    logger.info("Wrote %s docs with no annotations to %s",
-                len(not_annotated_docs), output_file)
+    logger.info(
+        "Wrote %s docs with token annotations to %s",
+        len(token_annotated_docs),
+        output_file,
+    )
+    logger.info(
+        "Wrote %s docs with no annotations to %s", len(not_annotated_docs), output_file
+    )

--- a/deep_reference_parser/prodigy/reference_to_token_annotations.py
+++ b/deep_reference_parser/prodigy/reference_to_token_annotations.py
@@ -126,6 +126,8 @@ class TokenTagger:
             for span in spans:
                 if self.lowercase:
                     label = span["label"].lower()
+                else:
+                    label = span["label"]
                 split_spans.extend(
                     self.split_long_span(tokens, span, label, label, label)
                 )

--- a/tests/prodigy/test_reference_to_token_annotations.py
+++ b/tests/prodigy/test_reference_to_token_annotations.py
@@ -42,108 +42,6 @@ def test_TokenTagger(tagger):
     assert out == tagged[0]["spans"]
 
 
-#def test_real_case():
-#    """
-#    Test real case observed where no `b-r` or `e-r` is present, the first and
-#    last `i-r` tokens are being replicated as `o` tokens when no bounding
-#    `b-r` or `e-r` tokens are present.
-#    """
-#
-#    doc = {
-#        "text": "d\n 2010, Actual",
-#        "spans":[
-#            {
-#                "start": 3,
-#                "end": 7,
-#                "token_start": 2,
-#                "token_end": 2,
-#                "label": "i-r"
-#            },
-#            {
-#                "start": 9,
-#                "end": 15,
-#                "token_start": 4,
-#                "token_end": 4,
-#                "label": "i-r"
-#            }
-#        ],
-#        "tokens":[
-#            {
-#                "text": "d",
-#                "start": 0,
-#                "end": 1,
-#                "id": 0
-#            },
-#            {
-#                "text": "\n ",
-#                "start": 1,
-#                "end": 3,
-#                "id": 1
-#            },
-#            {
-#                "text": "2010",
-#                "start": 3,
-#                "end": 7,
-#                "id": 2
-#            },
-#            {
-#                "text": ",",
-#                "start": 7,
-#                "end": 8,
-#                "id": 3
-#            },
-#            {
-#                "text": "Actual",
-#                "start": 9,
-#                "end": 15,
-#                "id": 4
-#            }
-#        ]}
-#
-#    after_spans = [
-#        {
-#            "start": 0,
-#            "end": 1,
-#            "token_start": 0,
-#            "token_end": 0,
-#            "label": "o"
-#        },
-#        {
-#            "start": 1,
-#            "end": 3,
-#            "token_start": 1,
-#            "token_end": 1,
-#            "label": "o"
-#        },
-#        {
-#            "start": 3,
-#            "end": 7,
-#            "token_start": 2,
-#            "token_end": 2,
-#            "label": "i-r"
-#        },
-#        {
-#            "start": 7,
-#            "end": 8,
-#            "token_start": 3,
-#            "token_end": 3,
-#            "label": "i-r"
-#        },
-#        {
-#            "start": 9,
-#            "end": 15,
-#            "token_start": 4,
-#            "token_end": 4,
-#            "label": "i-r"
-#        }
-#    ]
-#
-#
-#    tagger = TokenTagger([doc])
-#    tagged = tagger.run()
-#
-#    assert after_spans == tagged[0]["spans"]
-
 def test_create_span(tagger):
 
     tokens = [
@@ -179,7 +77,7 @@ def test_split_long_span(tagger):
         {'start': 4, 'end': 4, 'token_start': 4, 'token_end': 4, 'label': 'e-r'},
     ]
 
-    out = tagger.split_long_span(tokens, span, start_label="b-r", end_label="e-r")
+    out = tagger.split_long_span(tokens, span, start_label="b-r", end_label="e-r", inside_label="i-r")
 
     assert out == after
 
@@ -206,7 +104,7 @@ def test_reference_spans_be(tagger):
         {'start': 4, 'end': 4, 'token_start': 4, 'token_end': 4, 'label': 'e-r'},
     ]
 
-    out = tagger.reference_spans(spans, tokens)
+    out = tagger.reference_spans(spans, tokens, task="splitting")
 
     assert out == after
 
@@ -232,7 +130,7 @@ def test_reference_spans_bi(tagger):
         {'start': 4, 'end': 4, 'token_start': 4, 'token_end': 4, 'label': 'i-r'},
     ]
 
-    out = tagger.reference_spans(spans, tokens)
+    out = tagger.reference_spans(spans, tokens, task="splitting")
 
     assert out == after
 
@@ -258,7 +156,7 @@ def test_reference_spans_ie(tagger):
         {'start': 4, 'end': 4, 'token_start': 4, 'token_end': 4, 'label': 'e-r'},
     ]
 
-    out = tagger.reference_spans(spans, tokens)
+    out = tagger.reference_spans(spans, tokens, task="splitting")
 
     assert out == after
 
@@ -284,7 +182,33 @@ def test_reference_spans_ii(tagger):
         {'start': 4, 'end': 4, 'token_start': 4, 'token_end': 4, 'label': 'i-r'},
     ]
 
-    out = tagger.reference_spans(spans, tokens)
+    out = tagger.reference_spans(spans, tokens, task="splitting")
+
+    assert out == after
+
+def test_reference_spans_author(tagger):
+
+    tokens = [
+        {'start': 0, 'end': 0, 'id': 0},
+        {'start': 1, 'end': 1, 'id': 1},
+        {'start': 2, 'end': 2, 'id': 2},
+        {'start': 3, 'end': 3, 'id': 3},
+        {'start': 4, 'end': 4, 'id': 4},
+        {'start': 5, 'end': 5, 'id': 5},
+        {'start': 6, 'end': 6, 'id': 6},
+    ]
+
+    spans = [
+        {'start': 2, 'end': 4, 'token_start': 2, 'token_end': 4, 'label': 'author'}
+    ]
+
+    after = [
+        {'start': 2, 'end': 2, 'token_start': 2, 'token_end': 2, 'label': 'author'},
+        {'start': 3, 'end': 3, 'token_start': 3, 'token_end': 3, 'label': 'author'},
+        {'start': 4, 'end': 4, 'token_start': 4, 'token_end': 4, 'label': 'author'},
+    ]
+
+    out = tagger.reference_spans(spans, tokens, task="parsing")
 
     assert out == after
 


### PR DESCRIPTION
Previously `ref_to_token_annotations` would only work in the splitting scenario of converting reference spans (`BI`, `BE`, `IE`, `II`) spans to token spans (`b-r`, `i-r`, `e-r`, `o`). This PR allows it also to be used for parsing spans where a reference span (author) can be converted to a series of token spans (author).

Relevant tests are added, along with improved documentation to the command itself.