### PR TITLE
Use tox for testsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ script:
 
 cache:
   directories:
-    - build
     - $HOME/.cache/pip
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install tox-travis
 
 script:
-  - make test
+  - tox
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - 3.7
 
 install:
-  - make virtualenv
   - pip install -r requirements_test.txt
+  - pip install tox-travis
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,6 @@ $(test_artefacts):
 
 .PHONY: test
 test: $(test_artefacts) test_embedding
-	$(VIRTUALENV)/bin/pytest --disable-warnings --tb=line --cov=deep_reference_parser
+	$(VIRTUALENV)/bin/tox
 
 all: virtualenv model embedding test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    integration: Depends on downloading data from S3

--- a/tests/test_deep_reference_parser.py
+++ b/tests/test_deep_reference_parser.py
@@ -59,6 +59,7 @@ def cfg():
     return cfg
 
 @pytest.mark.slow
+@pytest.mark.integration
 def test_DeepReferenceParser_train(tmpdir, cfg):
     """
     This test creates the artefacts that will be used in the next test
@@ -114,6 +115,7 @@ def test_DeepReferenceParser_train(tmpdir, cfg):
 
 
 @pytest.mark.slow
+@pytest.mark.integration
 def test_DeepReferenceParser_predict(tmpdir, cfg):
     """
     You must run this test after the previous one, or it will fail

--- a/tests/test_deep_reference_parser.py
+++ b/tests/test_deep_reference_parser.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import os
 import shutil
 import tempfile
 
 import pytest
-from wasabi import msg
-
 from deep_reference_parser import DeepReferenceParser, get_config, load_tsv
+from deep_reference_parser.common import download_model_artefact
+from wasabi import msg
 
 from .common import TEST_CFG, TEST_TSV_PREDICT, TEST_TSV_TRAIN
 
@@ -17,10 +18,45 @@ def tmpdir(tmpdir_factory):
     return tmpdir_factory.mktemp("data")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def cfg():
-    return get_config(TEST_CFG)
+    cfg = get_config(TEST_CFG)
 
+    artefacts = [
+        "char2ind.pickle",
+        "ind2label.pickle",
+        "ind2word.pickle",
+        "label2ind.pickle",
+        "maxes.pickle",
+        "weights.h5",
+        "word2ind.pickle",
+    ]
+
+    S3_SLUG = cfg["data"]["s3_slug"]
+    OUTPUT_PATH = cfg["build"]["output_path"]
+    WORD_EMBEDDINGS = cfg["build"]["word_embeddings"]
+
+    for artefact in artefacts:
+        with msg.loading(f"Could not find {artefact} locally, downloading..."):
+            try:
+                artefact = os.path.join(OUTPUT_PATH, artefact)
+                download_model_artefact(artefact, S3_SLUG)
+                msg.good(f"Found {artefact}")
+            except:
+                msg.fail(f"Could not download {S3_SLUG}{artefact}")
+
+    # Check on word embedding and download if not exists
+
+    WORD_EMBEDDINGS = cfg["build"]["word_embeddings"]
+
+    with msg.loading(f"Could not find {WORD_EMBEDDINGS} locally, downloading..."):
+        try:
+            download_model_artefact(WORD_EMBEDDINGS, S3_SLUG)
+            msg.good(f"Found {WORD_EMBEDDINGS}")
+        except:
+            msg.fail(f"Could not download {S3_SLUG}{WORD_EMBEDDINGS}")
+
+    return cfg
 
 @pytest.mark.slow
 def test_DeepReferenceParser_train(tmpdir, cfg):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py37
+
+[testenv]
+deps=-rrequirements_test.txt
+commands=pytest --tb=line --cov=deep_reference_parser --cov-append --disable-warnings


### PR DESCRIPTION
tox installs the package first and then runs the tests on it, rather than running the tests using the environment installed by `make virtualenv`. This ensures that the package that is delivered to users is performing as expected.