### PR TITLE
Pinning keras and tensorflow versions in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setuptools.setup(
     install_requires=[
         "spacy<2.2.0",
         "pandas",
-        "tensorflow",
-        "keras",
-        "keras-contrib @ https://github.com/keras-team/keras-contrib/tarball/master",
+        "tensorflow==1.15.2",
+        "keras==2.2.5",
+        "keras-contrib @ https://github.com/keras-team/keras-contrib/tarball/5ffab172661411218e517a50170bb97760ea567b",
         "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz#egg=en_core_web_sm==2.1.0",
         "sklearn",
         "sklearn_crfsuite",


### PR DESCRIPTION
The new Keras version 2.4.0 released in June 2020 made changes that broke the deep reference parser.
```
 File "/usr/local/lib/python3.6/site-packages/deep_reference_parser/deep_reference_parser.py", line 989, in load_weights
    saving.load_weights_from_hdf5_group(

AttributeError: module 'keras.engine.saving' has no attribute 'load_weights_from_hdf5_group'
```

Thus I've pinned the version of keras to 2.2.5 (which is whats in the requirements). I also needed to pin the version of keras-contrib since it overwrote keras 2.2.5 to the newer version. Then I got issues with tensorflow, so also pinned this to the version in the requirements.
